### PR TITLE
Feed factory uses own post registry, punish uses msg.sender

### DIFF
--- a/contracts/agreements/CountdownGriefing.sol
+++ b/contracts/agreements/CountdownGriefing.sol
@@ -92,7 +92,7 @@ contract CountdownGriefing is Countdown, Griefing, Metadata, Operated, Template 
         Staking._addStake(_data.staker, msg.sender, currentStake, amountToAdd);
     }
 
-    function punish(address from, uint256 currentStake, uint256 punishment, bytes memory message) public returns (uint256 cost) {
+    function punish(uint256 currentStake, uint256 punishment, bytes memory message) public returns (uint256 cost) {
         // restrict access
         require(isCounterparty(msg.sender) || Operated.isActiveOperator(msg.sender), "only counterparty or active operator");
 
@@ -100,7 +100,7 @@ contract CountdownGriefing is Countdown, Griefing, Metadata, Operated, Template 
         require(!Countdown.isOver(), "agreement ended");
 
         // execute griefing
-        cost = Griefing._grief(from, _data.staker, currentStake, punishment, message);
+        cost = Griefing._grief(msg.sender, _data.staker, currentStake, punishment, message);
     }
 
     function startCountdown() public returns (uint256 deadline) {

--- a/contracts/agreements/SimpleGriefing.sol
+++ b/contracts/agreements/SimpleGriefing.sol
@@ -81,12 +81,12 @@ contract SimpleGriefing is Griefing, Metadata, Operated, Template {
         Staking._addStake(_data.staker, msg.sender, currentStake, amountToAdd);
     }
 
-    function punish(address from, uint256 currentStake, uint256 punishment, bytes memory message) public returns (uint256 cost) {
+    function punish(uint256 currentStake, uint256 punishment, bytes memory message) public returns (uint256 cost) {
         // restrict access
         require(isCounterparty(msg.sender) || Operated.isActiveOperator(msg.sender), "only counterparty or active operator");
 
         // execute griefing
-        cost = Griefing._grief(from, _data.staker, currentStake, punishment, message);
+        cost = Griefing._grief(msg.sender, _data.staker, currentStake, punishment, message);
     }
 
     function releaseStake(uint256 currentStake, uint256 amountToRelease) public {

--- a/contracts/posts/Feed_Factory.sol
+++ b/contracts/posts/Feed_Factory.sol
@@ -28,21 +28,21 @@ contract Feed_Factory is Factory {
         // decode initdata
         (
             address operator,
-            address postRegistry,
             bytes memory feedStaticMetadata
-        ) = abi.decode(initdata, (address,address,bytes));
+        ) = abi.decode(initdata, (address,bytes));
 
         // call explicit create
-        instance = createExplicit(operator, postRegistry, feedStaticMetadata);
+        instance = createExplicit(operator, feedStaticMetadata);
     }
 
     function createExplicit(
         address operator,
-        address postRegistry,
         bytes memory feedStaticMetadata
     ) public returns (address instance) {
         // declare template in memory
         Feed template;
+
+        address postRegistry = Factory.getInstanceRegistry();
 
         // construct the data payload used when initializing the new contract.
         bytes memory callData = abi.encodeWithSelector(

--- a/contracts/test-contracts/TestCountdownGriefing.sol
+++ b/contracts/test-contracts/TestCountdownGriefing.sol
@@ -99,10 +99,10 @@ contract TestCountdownGriefing is CountdownGriefing {
         _deadline = deadline;
     }
 
-    function punish(address from, uint256 currentStake, uint256 punishment, bytes memory message) public returns (uint256 cost) {
+    function punish(uint256 currentStake, uint256 punishment, bytes memory message) public returns (uint256 cost) {
         bytes memory callData = abi.encodeWithSelector(
             _template.punish.selector,
-            from, currentStake, punishment, message
+            currentStake, punishment, message
         );
         (bool ok, bytes memory data) = _griefingContract.delegatecall(callData);
         require(ok, string(data));

--- a/contracts/test-contracts/TestSimpleGriefing.sol
+++ b/contracts/test-contracts/TestSimpleGriefing.sol
@@ -85,10 +85,10 @@ contract TestSimpleGriefing is SimpleGriefing {
         require(ok, string(data));
     }
 
-    function punish(address from, uint256 currentStake, uint256 punishment, bytes memory message) public returns (uint256 cost) {
+    function punish(uint256 currentStake, uint256 punishment, bytes memory message) public returns (uint256 cost) {
         bytes memory callData = abi.encodeWithSelector(
             _template.punish.selector,
-            from, currentStake, punishment, message
+            currentStake, punishment, message
         );
         (bool ok, bytes memory data) = _griefingContract.delegatecall(callData);
         require(ok, string(data));

--- a/test/agreements/CountdownGriefing.js
+++ b/test/agreements/CountdownGriefing.js
@@ -513,7 +513,6 @@ describe("CountdownGriefing", function() {
       );
 
       const txn = await this.TestCountdownGriefing.from(counterparty).punish(
-        from,
         currentStake,
         punishment,
         Buffer.from(message)
@@ -557,7 +556,6 @@ describe("CountdownGriefing", function() {
       // staker is not counterparty or operator
       await assert.revertWith(
         this.TestCountdownGriefing.from(staker).punish(
-          from,
           currentStake,
           punishment,
           Buffer.from(message)
@@ -587,7 +585,6 @@ describe("CountdownGriefing", function() {
 
       await assert.revertWith(
         this.TestCountdownGriefing.from(counterparty).punish(
-          from,
           currentStake,
           punishment,
           Buffer.from(message)
@@ -604,7 +601,6 @@ describe("CountdownGriefing", function() {
 
       await assert.revertWith(
         this.TestCountdownGriefing.from(counterparty).punish(
-          from,
           currentStake,
           punishment,
           Buffer.from(message)
@@ -616,7 +612,6 @@ describe("CountdownGriefing", function() {
     it("should revert when currentStake is incorrect", async () => {
       await assert.revertWith(
         this.TestCountdownGriefing.from(counterparty).punish(
-          from,
           currentStake.add(1),
           punishment,
           Buffer.from(message)

--- a/test/agreements/SimpleGriefing.js
+++ b/test/agreements/SimpleGriefing.js
@@ -395,7 +395,6 @@ describe("SimpleGriefing", function() {
       );
 
       const txn = await this.TestSimpleGriefing.from(counterparty).punish(
-        from,
         currentStake,
         punishment,
         Buffer.from(message)
@@ -439,7 +438,6 @@ describe("SimpleGriefing", function() {
       // staker is not counterparty or operator
       await assert.revertWith(
         this.TestSimpleGriefing.from(staker).punish(
-          from,
           currentStake,
           punishment,
           Buffer.from(message)
@@ -451,7 +449,6 @@ describe("SimpleGriefing", function() {
     it("should revert when no approval to burn tokens", async () => {
       await assert.revertWith(
         this.TestSimpleGriefing.from(counterparty).punish(
-          from,
           currentStake,
           punishment,
           Buffer.from(message)

--- a/test/modules/Factory.js
+++ b/test/modules/Factory.js
@@ -9,17 +9,17 @@ function testFactory(
   deployer, // etherlime's ganache deployer instance
   factoryName, // factory contract's name
   instanceType, // instance type created by factory
-  createTypes, // the actual types used to encode the init data ABI function parameters
-  createArgs, // the actual types used to encode init data values
+  createExplicitTypes, // the types used in createExplicit call
+  createExplicitArgs, // the arguments used in createExplicit call
   factoryArtifact, // the factory artifact
   registryArtifact, // correct registry used to store instances & factories. instanceType must match
-  wrongRegistryArtifact // wrong registry for error testing. instanceType must mismatch
+  wrongRegistryArtifact, // wrong registry for error testing. instanceType must mismatch
 
-  // There are cases where the create() call and the instance address creation's
+  // There are cases where the create() call and the createExplicit() call differ
   // ABI types are different. Default to the create call parameters
   // anything else, pass in a different set of ABI
-  // createInstanceTypes = createTypes,
-  // createInstanceArgs = createArgs
+  createTypes = createExplicitTypes,
+  getCreateArgs = () => createExplicitArgs
 ) {
   describe(factoryName, function() {
     this.timeout(4000);
@@ -42,6 +42,8 @@ function testFactory(
     before(async () => {
       this.Registry = await deployer.deploy(registryArtifact);
       this.WrongRegistry = await deployer.deploy(wrongRegistryArtifact);
+
+      getCreateArgs = getCreateArgs.bind(this);
     });
 
     const createLocalInstance = () => {
@@ -52,7 +54,7 @@ function testFactory(
         creator,
         initializeFunctionName,
         createTypes,
-        createArgs,
+        getCreateArgs(),
         nonce
       );
 
@@ -64,7 +66,7 @@ function testFactory(
 
     const populateInstances = async count => {
       for (let i = 0; i < count; i++) {
-        await this.Factory.from(creator).createExplicit(...createArgs);
+        await this.Factory.from(creator).createExplicit(...createExplicitArgs);
         createLocalInstance();
       }
     };
@@ -159,7 +161,7 @@ function testFactory(
         const callData = abiEncodeWithSelector(
           initializeFunctionName,
           createTypes,
-          createArgs
+          getCreateArgs()
         );
         const txn = await this.Factory.from(creator).create(callData);
         await validateCreateExplicitTxn(txn);
@@ -170,7 +172,10 @@ function testFactory(
       const abiEncoder = new ethers.utils.AbiCoder();
 
       it("should create instance correctly", async () => {
-        const initData = abiEncoder.encode(createTypes, createArgs);
+        const initData = abiEncoder.encode(
+          createExplicitTypes,
+          createExplicitArgs
+        );
         const txn = await this.Factory.from(creator).createEncoded(initData);
         await validateCreateExplicitTxn(txn);
       });
@@ -180,7 +185,7 @@ function testFactory(
       it("should create instance correctly", async () => {
         // creator creates the OneWayGriefing instance
         const txn = await this.Factory.from(creator).createExplicit(
-          ...createArgs
+          ...createExplicitArgs
         );
 
         await validateCreateExplicitTxn(txn);

--- a/test/posts/Feed_Factory.js
+++ b/test/posts/Feed_Factory.js
@@ -16,7 +16,8 @@ const staticMetadata = ethers.utils.keccak256(
   ethers.utils.toUtf8Bytes("staticMetadata")
 );
 
-const createTypes = ["address", "address", "bytes"];
+const createTypes = ["address", "bytes"];
+const localCreateTypes = ["address", "address", "bytes"];
 
 let PostRegistry;
 
@@ -29,13 +30,7 @@ function runFactoryTest() {
 
   describe(factoryName, () => {
     it("setups test", () => {
-      const createArgs = [
-        creator,
-        // this PostRegistry will not be used in the Factory.js tests
-        // just used as a placeholder
-        PostRegistry.contractAddress,
-        staticMetadata
-      ];
+      const createArgs = [creator, staticMetadata];
 
       testFactory(
         deployer,
@@ -45,7 +40,11 @@ function runFactoryTest() {
         createArgs,
         FeedFactoryArtifact,
         ErasurePostsArtifact, // correct registry
-        ErasureAgreementsArtifact // wrong registry
+        ErasureAgreementsArtifact, // wrong registry
+        localCreateTypes,
+        function() {
+          return [creator, this.Registry.contractAddress, staticMetadata];
+        }
       );
     });
   });


### PR DESCRIPTION
To be made compatible with recent changes to Factory

Changes conflict with https://github.com/erasureprotocol/erasure-protocol/pull/180/commits/264579ffcf5dbce0db136c6e791f1afb0bfee04b