### PR TITLE
[Subgraph] minor fixes

### DIFF
--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "codegen": "graph codegen",
-    "build": "graph build",
+    "build": "graph build"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.15.0",

--- a/packages/subgraph/src/mapping.ts
+++ b/packages/subgraph/src/mapping.ts
@@ -409,7 +409,7 @@ export function handleGriefedOneWayGriefing(event: GriefedOneWayGriefingEvent): 
   entity.save()
 
   let oneWayGriefing = new OneWayGriefingAgreement(event.address.toHex())
-  oneWayGriefing.stake = oneWayGriefing.stake.minus(entity.punishment)
+  oneWayGriefing.staker = entity.staker
   oneWayGriefing.save()
 }
 
@@ -458,6 +458,7 @@ export function handleStakeTakenOneWayGriefing(event: StakeTakenOneWayGriefingEv
   entity.save()
 
   let oneWayGriefing = new OneWayGriefingAgreement(event.address.toHex())
+  oneWayGriefing.staker = entity.staker
   oneWayGriefing.stake = entity.newStake
   oneWayGriefing.save()
 }
@@ -474,6 +475,7 @@ export function handleStakeBurnedOneWayGriefing(event: StakeBurnedOneWayGriefing
   entity.save()
 
   let oneWayGriefing = new OneWayGriefingAgreement(event.address.toHex())
+  oneWayGriefing.staker = entity.staker
   oneWayGriefing.stake = entity.newStake
   oneWayGriefing.save()
 }

--- a/packages/subgraph/yarn.lock
+++ b/packages/subgraph/yarn.lock
@@ -165,9 +165,9 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-"assemblyscript@git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3":
+"assemblyscript@https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3":
   version "0.6.0"
-  resolved "git+https://github.com/AssemblyScript/assemblyscript.git#36040d5b5312f19a025782b5e36663823494c2f3"
+  resolved "https://github.com/AssemblyScript/assemblyscript#36040d5b5312f19a025782b5e36663823494c2f3"
   dependencies:
     "@protobufjs/utf8" "^1.1.0"
     binaryen "77.0.0-nightly.20190407"


### PR DESCRIPTION
- catch `staker` as much as possible to alleviate issue with missing `staker` when agreement is created using `create`
- stop double counting burns