### PR TITLE
Refactor of Factories

### DIFF
--- a/contracts/agreements/CountdownGriefing.sol
+++ b/contracts/agreements/CountdownGriefing.sol
@@ -27,10 +27,14 @@ contract CountdownGriefing is Countdown, Griefing, Metadata, Operated, Template 
         address counterparty;
     }
 
-    event Initialized(address token, address operator, address staker, address counterparty, uint256 ratio, Griefing.RatioType ratioType, uint256 countdownLength, bytes staticMetadata)
+    event Initialized(address token, address operator, address staker, address counterparty, uint256 ratio, Griefing.RatioType ratioType, uint256 countdownLength, bytes staticMetadata);
+
+    constructor(address token) public {
+        // set token used for staking
+        Staking._setToken(token);
+    }
 
     function initialize(
-        address token,
         address operator,
         address staker,
         address counterparty,
@@ -48,9 +52,6 @@ contract CountdownGriefing is Countdown, Griefing, Metadata, Operated, Template 
             Operated._setOperator(operator);
             Operated._activateOperator();
         }
-
-        // set token used for staking
-        Staking._setToken(token);
 
         // set griefing ratio
         Griefing._setRatio(staker, ratio, ratioType);

--- a/contracts/agreements/CountdownGriefing.sol
+++ b/contracts/agreements/CountdownGriefing.sol
@@ -7,6 +7,7 @@ import "../modules/Griefing.sol";
 import "../modules/Metadata.sol";
 import "../modules/Operated.sol";
 import "../modules/Template.sol";
+import "../modules/iRegistry.sol";
 
 /* Immediately engage with specific buyer
  * - Stake can be increased at any time.
@@ -57,9 +58,10 @@ contract CountdownGriefing is Countdown, Griefing, Metadata, Operated, Template 
         // set static metadata
         Metadata._setStaticMetadata(staticMetadata);
 
-        bytes memory templateData = Template.getTemplateData();
+        // fetch factoryData from registry
+        bytes memory factoryData = Template.getFactoryData();
 
-        (address token) = abi.decode(templateData, (address));
+        (address token) = abi.decode(factoryData, (address));
 
         Staking._setToken(token);
 

--- a/contracts/agreements/CountdownGriefing.sol
+++ b/contracts/agreements/CountdownGriefing.sol
@@ -29,11 +29,6 @@ contract CountdownGriefing is Countdown, Griefing, Metadata, Operated, Template 
 
     event Initialized(address token, address operator, address staker, address counterparty, uint256 ratio, Griefing.RatioType ratioType, uint256 countdownLength, bytes staticMetadata);
 
-    constructor(address token) public {
-        // set token used for staking
-        Staking._setToken(token);
-    }
-
     function initialize(
         address operator,
         address staker,
@@ -61,6 +56,12 @@ contract CountdownGriefing is Countdown, Griefing, Metadata, Operated, Template 
 
         // set static metadata
         Metadata._setStaticMetadata(staticMetadata);
+
+        bytes memory templateData = Template.getTemplateData();
+
+        (address token) = abi.decode(templateData, (address));
+
+        Staking._setToken(token);
 
         // log initialization params
         emit Initialized(token, operator, staker, counterparty, ratio, ratioType, countdownLength, staticMetadata);

--- a/contracts/agreements/CountdownGriefing_Factory.sol
+++ b/contracts/agreements/CountdownGriefing_Factory.sol
@@ -6,10 +6,9 @@ import "./CountdownGriefing.sol";
 
 contract CountdownGriefing_Factory is Factory {
 
-    constructor(address instanceRegistry) public {
-        // deploy template contract
-        CountdownGriefing template = new CountdownGriefing();
-        address templateContract = address(template);
+    constructor(address instanceRegistry, address templateContract) public {
+        CountdownGriefing template;
+
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Agreement')));
         // set initSelector

--- a/contracts/agreements/CountdownGriefing_Factory.sol
+++ b/contracts/agreements/CountdownGriefing_Factory.sol
@@ -6,15 +6,18 @@ import "./CountdownGriefing.sol";
 
 contract CountdownGriefing_Factory is Factory {
 
-    constructor(address instanceRegistry, address templateContract) public {
+    constructor(address instanceRegistry, address templateContract, address token) public {
         CountdownGriefing template;
 
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Agreement')));
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
+
+        bytes memory templateData = abi.encode(token);
+
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, templateData);
     }
 
 }

--- a/contracts/agreements/CountdownGriefing_Factory.sol
+++ b/contracts/agreements/CountdownGriefing_Factory.sol
@@ -6,7 +6,7 @@ import "./CountdownGriefing.sol";
 
 contract CountdownGriefing_Factory is Factory {
 
-    constructor(address instanceRegistry, address templateContract, address token) public {
+    constructor(address instanceRegistry, address templateContract) public {
         CountdownGriefing template;
 
         // set instance type
@@ -14,10 +14,8 @@ contract CountdownGriefing_Factory is Factory {
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
 
-        bytes memory templateData = abi.encode(token);
-
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, templateData);
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
     }
 
 }

--- a/contracts/agreements/MultiPartyGriefing_Factory.sol
+++ b/contracts/agreements/MultiPartyGriefing_Factory.sol
@@ -6,16 +6,16 @@ import "./MultiPartyGriefing.sol";
 
 contract MultiPartyGriefing_Factory is Factory {
 
-    constructor(address instanceRegistry) public {
-        // deploy template contract
-        MultiPartyGriefing template = new MultiPartyGriefing();
-        address templateContract = address(template);
+    constructor(address instanceRegistry, address templateContract, address token) public {
+        MultiPartyGriefing template;
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Agreement')));
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
+        // pass in template data
+        bytes memory templateData = abi.encode(token);
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, templateData);
     }
 
 }

--- a/contracts/agreements/MultiPartyGriefing_Factory.sol
+++ b/contracts/agreements/MultiPartyGriefing_Factory.sol
@@ -6,16 +6,14 @@ import "./MultiPartyGriefing.sol";
 
 contract MultiPartyGriefing_Factory is Factory {
 
-    constructor(address instanceRegistry, address templateContract, address token) public {
+    constructor(address instanceRegistry, address templateContract) public {
         MultiPartyGriefing template;
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Agreement')));
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
-        // pass in template data
-        bytes memory templateData = abi.encode(token);
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, templateData);
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
     }
 
 }

--- a/contracts/agreements/SimpleGriefing.sol
+++ b/contracts/agreements/SimpleGriefing.sol
@@ -27,9 +27,12 @@ contract SimpleGriefing is Griefing, Metadata, Operated, Template {
     }
 
     event Initialized(address token, address operator, address staker, address counterparty, uint256 ratio, Griefing.RatioType ratioType, bytes staticMetadata);
+    constructor(address token) public {
+        // set token used for staking
+        Staking._setToken(token);
+    }
 
     function initialize(
-        address token,
         address operator,
         address staker,
         address counterparty,
@@ -46,9 +49,6 @@ contract SimpleGriefing is Griefing, Metadata, Operated, Template {
             Operated._setOperator(operator);
             Operated._activateOperator();
         }
-
-        // set token used for staking
-        Staking._setToken(token);
 
         // set griefing ratio
         Griefing._setRatio(staker, ratio, ratioType);

--- a/contracts/agreements/SimpleGriefing.sol
+++ b/contracts/agreements/SimpleGriefing.sol
@@ -27,10 +27,6 @@ contract SimpleGriefing is Griefing, Metadata, Operated, Template {
     }
 
     event Initialized(address token, address operator, address staker, address counterparty, uint256 ratio, Griefing.RatioType ratioType, bytes staticMetadata);
-    constructor(address token) public {
-        // set token used for staking
-        Staking._setToken(token);
-    }
 
     function initialize(
         address operator,
@@ -55,6 +51,10 @@ contract SimpleGriefing is Griefing, Metadata, Operated, Template {
 
         // set static metadata
         Metadata._setStaticMetadata(staticMetadata);
+
+        bytes memory templateData = Template.getTemplateData();
+
+        (address token) = abi.decode(templateData, (address));
 
         // log initialization params
         emit Initialized(token, operator, staker, counterparty, ratio, ratioType, staticMetadata);

--- a/contracts/agreements/SimpleGriefing.sol
+++ b/contracts/agreements/SimpleGriefing.sol
@@ -52,9 +52,10 @@ contract SimpleGriefing is Griefing, Metadata, Operated, Template {
         // set static metadata
         Metadata._setStaticMetadata(staticMetadata);
 
-        bytes memory templateData = Template.getTemplateData();
+        // fetch factoryData from registry
+        bytes memory factoryData = Template.getFactoryData();
 
-        (address token) = abi.decode(templateData, (address));
+        (address token) = abi.decode(factoryData, (address));
 
         // log initialization params
         emit Initialized(token, operator, staker, counterparty, ratio, ratioType, staticMetadata);

--- a/contracts/agreements/SimpleGriefing_Factory.sol
+++ b/contracts/agreements/SimpleGriefing_Factory.sol
@@ -6,16 +6,14 @@ import "./SimpleGriefing.sol";
 
 contract SimpleGriefing_Factory is Factory {
 
-    constructor(address instanceRegistry, address templateContract, address token) public {
+    constructor(address instanceRegistry, address templateContract) public {
         SimpleGriefing template;
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Agreement')));
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
-        // pass in template data
-        bytes memory templateData = abi.encode(token);
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, templateData);
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
     }
 
 }

--- a/contracts/agreements/SimpleGriefing_Factory.sol
+++ b/contracts/agreements/SimpleGriefing_Factory.sol
@@ -6,14 +6,16 @@ import "./SimpleGriefing.sol";
 
 contract SimpleGriefing_Factory is Factory {
 
-    constructor(address instanceRegistry, address templateContract) public {
+    constructor(address instanceRegistry, address templateContract, address token) public {
         SimpleGriefing template;
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Agreement')));
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
+        // pass in template data
+        bytes memory templateData = abi.encode(token);
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, templateData);
     }
 
 }

--- a/contracts/agreements/SimpleGriefing_Factory.sol
+++ b/contracts/agreements/SimpleGriefing_Factory.sol
@@ -6,10 +6,8 @@ import "./SimpleGriefing.sol";
 
 contract SimpleGriefing_Factory is Factory {
 
-    constructor(address instanceRegistry) public {
-        // deploy template contract
-        SimpleGriefing template = new SimpleGriefing();
-        address templateContract = address(template);
+    constructor(address instanceRegistry, address templateContract) public {
+        SimpleGriefing template;
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Agreement')));
         // set initSelector

--- a/contracts/agreements/TwoWayGriefing_Factory.sol
+++ b/contracts/agreements/TwoWayGriefing_Factory.sol
@@ -6,16 +6,14 @@ import "./TwoWayGriefing.sol";
 
 contract TwoWayGriefing_Factory is Factory {
 
-    constructor(address instanceRegistry, address templateContract, address token) public {
+    constructor(address instanceRegistry, address templateContract) public {
         TwoWayGriefing template;
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Agreement')));
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
-        // pass in template data
-        bytes memory templateData = abi.encode(token);
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, templateData);
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
     }
 
 }

--- a/contracts/agreements/TwoWayGriefing_Factory.sol
+++ b/contracts/agreements/TwoWayGriefing_Factory.sol
@@ -6,16 +6,16 @@ import "./TwoWayGriefing.sol";
 
 contract TwoWayGriefing_Factory is Factory {
 
-    constructor(address instanceRegistry) public {
-        // deploy template contract
-        TwoWayGriefing template = new TwoWayGriefing();
-        address templateContract = address(template);
+    constructor(address instanceRegistry, address templateContract, address token) public {
+        TwoWayGriefing template;
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Agreement')));
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
+        // pass in template data
+        bytes memory templateData = abi.encode(token);
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, templateData);
     }
 
 }

--- a/contracts/modules/Factory.sol
+++ b/contracts/modules/Factory.sol
@@ -14,10 +14,17 @@ contract Factory is Spawner {
     bytes4 private _initSelector;
     address private _instanceRegistry;
     bytes4 private _instanceType;
+    bytes private _templateData;
 
     event InstanceCreated(address indexed instance, address indexed creator, bytes callData);
 
-    function _initialize(address instanceRegistry, address templateContract, bytes4 instanceType, bytes4 initSelector) internal {
+    function _initialize(
+        address instanceRegistry,
+        address templateContract,
+        bytes4 instanceType,
+        bytes4 initSelector,
+        bytes memory templateData
+    ) internal {
         // set instance registry
         _instanceRegistry = instanceRegistry;
         // set logic contract
@@ -28,6 +35,8 @@ contract Factory is Spawner {
         require(instanceType == iRegistry(instanceRegistry).getInstanceType(), 'incorrect instance type');
         // set instanceType
         _instanceType = instanceType;
+        // set metadata bytes string
+        _templateData = templateData;
     }
 
     // IFactory methods
@@ -72,6 +81,10 @@ contract Factory is Spawner {
 
     function getInstanceCreator(address instance) public view returns (address creator) {
         creator = _instanceCreator[instance];
+    }
+
+    function getTemplateData() public view returns (bytes memory templateData) {
+        templateData = _templateData;
     }
 
     function getInstanceType() public view returns (bytes4 instanceType) {

--- a/contracts/modules/Factory.sol
+++ b/contracts/modules/Factory.sol
@@ -14,7 +14,6 @@ contract Factory is Spawner {
     bytes4 private _initSelector;
     address private _instanceRegistry;
     bytes4 private _instanceType;
-    bytes private _templateData;
 
     event InstanceCreated(address indexed instance, address indexed creator, bytes callData);
 
@@ -22,8 +21,7 @@ contract Factory is Spawner {
         address instanceRegistry,
         address templateContract,
         bytes4 instanceType,
-        bytes4 initSelector,
-        bytes memory templateData
+        bytes4 initSelector
     ) internal {
         // set instance registry
         _instanceRegistry = instanceRegistry;
@@ -35,8 +33,6 @@ contract Factory is Spawner {
         require(instanceType == iRegistry(instanceRegistry).getInstanceType(), 'incorrect instance type');
         // set instanceType
         _instanceType = instanceType;
-        // set metadata bytes string
-        _templateData = templateData;
     }
 
     // IFactory methods
@@ -81,10 +77,6 @@ contract Factory is Spawner {
 
     function getInstanceCreator(address instance) public view returns (address creator) {
         creator = _instanceCreator[instance];
-    }
-
-    function getTemplateData() public view returns (bytes memory templateData) {
-        templateData = _templateData;
     }
 
     function getInstanceType() public view returns (bytes4 instanceType) {

--- a/contracts/modules/Template.sol
+++ b/contracts/modules/Template.sol
@@ -31,4 +31,8 @@ contract Template {
         ok = (caller == getCreator());
     }
 
+    function getTemplateData() public view returns (bytes memory templateData) {
+        templateData = iFactory(_factory).getTemplateData();
+    }
+
 }

--- a/contracts/modules/Template.sol
+++ b/contracts/modules/Template.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.0;
 
 import "./iFactory.sol";
+import "./iRegistry.sol";
 
 
 contract Template {
@@ -31,8 +32,14 @@ contract Template {
         ok = (caller == getCreator());
     }
 
-    function getTemplateData() public view returns (bytes memory templateData) {
-        templateData = iFactory(_factory).getTemplateData();
+    function getFactory() public view returns (address factory) {
+        factory = _factory;
+    }
+
+    function getFactoryData() public view returns (bytes memory factoryData) {
+        address myFactory = Template.getFactory();
+        address registry = iFactory(myFactory).getInstanceRegistry();
+        factoryData = iRegistry(registry).getFactoryData(myFactory);
     }
 
 }

--- a/contracts/modules/iFactory.sol
+++ b/contracts/modules/iFactory.sol
@@ -20,6 +20,7 @@ pragma solidity ^0.5.0;
      function getSaltyInstance(bytes calldata, bytes32 salt) external view returns (address instance);
      function getNextInstance(bytes calldata) external view returns (address instance);
 
+     function getTemplateData() external view returns (bytes memory metadata);
      function getInstanceCreator(address instance) external view returns (address creator);
      function getInstanceType() external view returns (bytes4 instanceType);
      function getInstanceCount() external view returns (uint256 count);

--- a/contracts/modules/iFactory.sol
+++ b/contracts/modules/iFactory.sol
@@ -20,7 +20,6 @@ pragma solidity ^0.5.0;
      function getSaltyInstance(bytes calldata, bytes32 salt) external view returns (address instance);
      function getNextInstance(bytes calldata) external view returns (address instance);
 
-     function getTemplateData() external view returns (bytes memory metadata);
      function getInstanceCreator(address instance) external view returns (address creator);
      function getInstanceType() external view returns (bytes4 instanceType);
      function getInstanceCount() external view returns (uint256 count);

--- a/contracts/posts/Feed_Factory.sol
+++ b/contracts/posts/Feed_Factory.sol
@@ -14,7 +14,7 @@ contract Feed_Factory is Factory {
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, "");
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
     }
 
 }

--- a/contracts/posts/Feed_Factory.sol
+++ b/contracts/posts/Feed_Factory.sol
@@ -14,7 +14,7 @@ contract Feed_Factory is Factory {
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, "");
     }
 
 }

--- a/contracts/posts/Feed_Factory.sol
+++ b/contracts/posts/Feed_Factory.sol
@@ -6,10 +6,9 @@ import "./Feed.sol";
 
 contract Feed_Factory is Factory {
 
-    constructor(address instanceRegistry) public {
-        // deploy template contract
-        Feed template = new Feed();
-        address templateContract = address(template);
+    constructor(address instanceRegistry, address templateContract) public {
+        Feed template;
+
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Post')));
         // set initSelector

--- a/contracts/posts/Post_Factory.sol
+++ b/contracts/posts/Post_Factory.sol
@@ -15,7 +15,7 @@ contract Post_Factory is Factory {
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, "");
     }
 
 }

--- a/contracts/posts/Post_Factory.sol
+++ b/contracts/posts/Post_Factory.sol
@@ -6,10 +6,10 @@ import "./Post.sol";
 
 contract Post_Factory is Factory {
 
-    constructor(address instanceRegistry) public {
-        // deploy template contract
-        Post template = new Post();
-        address templateContract = address(template);
+    constructor(address instanceRegistry, address templateContract) public {
+        // declare template in memory
+        Post template;
+
         // set instance type
         bytes4 instanceType = bytes4(keccak256(bytes('Post')));
         // set initSelector

--- a/contracts/posts/Post_Factory.sol
+++ b/contracts/posts/Post_Factory.sol
@@ -15,7 +15,7 @@ contract Post_Factory is Factory {
         // set initSelector
         bytes4 initSelector = template.initialize.selector;
         // initialize factory params
-        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector, "");
+        Factory._initialize(instanceRegistry, templateContract, instanceType, initSelector);
     }
 
 }

--- a/contracts/test-contracts/TestCountdownGriefing.sol
+++ b/contracts/test-contracts/TestCountdownGriefing.sol
@@ -19,11 +19,10 @@ contract TestCountdownGriefing is CountdownGriefing {
         uint256 ratio,
         Griefing.RatioType ratioType,
         uint256 countdownLength,
-        bytes memory staticMetadata) public {
+        bytes memory staticMetadata) CountdownGriefing(token) public {
 
         initializeCountdownGriefing(
             griefingContract,
-            token,
             operator,
             staker,
             counterparty,
@@ -36,7 +35,6 @@ contract TestCountdownGriefing is CountdownGriefing {
 
     function initializeCountdownGriefing(
         address griefingContract,
-        address token,
         address operator,
         address staker,
         address counterparty,
@@ -49,7 +47,6 @@ contract TestCountdownGriefing is CountdownGriefing {
 
         bytes memory initData = abi.encodeWithSelector(
             _template.initialize.selector, // selector
-            token,           // token
             operator,        // operator
             staker,          // staker
             counterparty,    // counterparty

--- a/contracts/test-contracts/TestCountdownGriefing.sol
+++ b/contracts/test-contracts/TestCountdownGriefing.sol
@@ -12,14 +12,13 @@ contract TestCountdownGriefing is CountdownGriefing {
 
     constructor(
         address griefingContract,
-        address token,
         address operator,
         address staker,
         address counterparty,
         uint256 ratio,
         Griefing.RatioType ratioType,
         uint256 countdownLength,
-        bytes memory staticMetadata) CountdownGriefing(token) public {
+        bytes memory staticMetadata) public {
 
         initializeCountdownGriefing(
             griefingContract,

--- a/contracts/test-contracts/TestSimpleGriefing.sol
+++ b/contracts/test-contracts/TestSimpleGriefing.sol
@@ -11,13 +11,12 @@ contract TestSimpleGriefing is SimpleGriefing {
 
     constructor(
         address griefingContract,
-        address token,
         address operator,
         address staker,
         address counterparty,
         uint256 ratio,
         Griefing.RatioType ratioType,
-        bytes memory staticMetadata) SimpleGriefing(token) public {
+        bytes memory staticMetadata) public {
 
         initializeSimpleGriefing(
             griefingContract,

--- a/contracts/test-contracts/TestSimpleGriefing.sol
+++ b/contracts/test-contracts/TestSimpleGriefing.sol
@@ -17,11 +17,10 @@ contract TestSimpleGriefing is SimpleGriefing {
         address counterparty,
         uint256 ratio,
         Griefing.RatioType ratioType,
-        bytes memory staticMetadata) public {
+        bytes memory staticMetadata) SimpleGriefing(token) public {
 
         initializeSimpleGriefing(
             griefingContract,
-            token,
             operator,
             staker,
             counterparty,
@@ -33,7 +32,6 @@ contract TestSimpleGriefing is SimpleGriefing {
 
     function initializeSimpleGriefing(
         address griefingContract,
-        address token,
         address operator,
         address staker,
         address counterparty,
@@ -45,7 +43,6 @@ contract TestSimpleGriefing is SimpleGriefing {
 
         bytes memory initData = abi.encodeWithSelector(
             _template.initialize.selector, // selector
-            token,           // token
             operator,        // operator
             staker,          // staker
             counterparty,    // counterparty

--- a/test/agreements/CountdownGriefing.js
+++ b/test/agreements/CountdownGriefing.js
@@ -2,7 +2,8 @@ const { createDeployer } = require("../helpers/setup");
 const { RATIO_TYPES } = require("../helpers/variables");
 
 const CountdownGriefingArtifact = require("../../build/CountdownGriefing.json");
-const TestCountdownGriefingArtifact = require("../../build/TestCountdownGriefing.json");
+const CountdownGriefingFactoryArtifact = require("../../build/CountdownGriefing_Factory.json");
+const AgreementRegistryArtifact = require("../../build/Erasure_Agreements.json");
 const MockNMRArtifact = require("../../build/MockNMR.json");
 
 describe("CountdownGriefing", function() {
@@ -58,10 +59,29 @@ describe("CountdownGriefing", function() {
     deployer = createDeployer();
 
     this.MockNMR = await deployer.deploy(MockNMRArtifact);
-    this.CountdownGriefing = await deployer.deploy(
-      CountdownGriefingArtifact,
+    this.AgreementsRegistry = await deployer.deploy(AgreementRegistryArtifact);
+
+    this.CountdownGriefingTemplate = await deployer.deploy(
+      CountdownGriefingArtifact
+    );
+
+    this.CountdownGriefingFactory = await deployer.deploy(
+      CountdownGriefingFactoryArtifact,
       false,
+      this.CountdownGriefingTemplate.contractAddress,
       this.MockNMR.contractAddress
+    );
+
+    const abiEncoder = new ethers.utils.AbiCoder();
+
+    const factoryData = abiEncoder.encode(
+      ["address"],
+      this.MockNMR.contractAddress
+    );
+
+    this.AgreementsRegistry.from(operator).addFactory(
+      this.CountdownGriefingFactory.contractAddress,
+      factoryData
     );
 
     // fill the token balances of the counterparty and staker

--- a/test/agreements/CountdownGriefing.js
+++ b/test/agreements/CountdownGriefing.js
@@ -57,8 +57,12 @@ describe("CountdownGriefing", function() {
   before(async () => {
     deployer = createDeployer();
 
-    this.CountdownGriefing = await deployer.deploy(CountdownGriefingArtifact);
     this.MockNMR = await deployer.deploy(MockNMRArtifact);
+    this.CountdownGriefing = await deployer.deploy(
+      CountdownGriefingArtifact,
+      false,
+      this.MockNMR.contractAddress
+    );
 
     // fill the token balances of the counterparty and staker
     // counterparty & staker has 1,000 * 10^18 each
@@ -76,10 +80,7 @@ describe("CountdownGriefing", function() {
   describe("CountdownGriefing.initialize", () => {
     it("should revert when caller is not contract", async () => {
       await assert.revertWith(
-        this.CountdownGriefing.initialize(
-          this.MockNMR.contractAddress,
-          ...initArgs
-        ),
+        this.CountdownGriefing.initialize(...initArgs),
         "must be called within contract constructor"
       );
     });
@@ -150,7 +151,6 @@ describe("CountdownGriefing", function() {
     it("should revert when not initialized from constructor", async () => {
       const initArgs = [
         this.CountdownGriefing.contractAddress,
-        this.MockNMR.contractAddress,
         operator,
         staker,
         counterparty,
@@ -497,7 +497,10 @@ describe("CountdownGriefing", function() {
       // increase staker's stake to 500
       await this.MockNMR.from(staker).changeApproval(
         this.TestCountdownGriefing.contractAddress,
-        (await this.MockNMR.allowance(staker, this.TestCountdownGriefing.contractAddress)),
+        await this.MockNMR.allowance(
+          staker,
+          this.TestCountdownGriefing.contractAddress
+        ),
         stakerStake
       );
       await this.TestCountdownGriefing.from(staker).increaseStake(

--- a/test/agreements/CountdownGriefing_Factory.js
+++ b/test/agreements/CountdownGriefing_Factory.js
@@ -1,5 +1,6 @@
 // require artifacts
-const OneWayGriefing_FactoryArtifact = require("../../build/CountdownGriefing_Factory.json");
+const CountdownGriefingArtifact = require("../../build/CountdownGriefing.json");
+const CountdownGriefing_FactoryArtifact = require("../../build/CountdownGriefing_Factory.json");
 const MockNMRArtifact = require("../../build/MockNMR.json");
 const ErasureAgreementsRegistryArtifact = require("../../build/Erasure_Agreements.json");
 const ErasurePostsRegistryArtifact = require("../../build/Erasure_Posts.json");
@@ -21,17 +22,21 @@ const createTypes = [
   "address",
   "address",
   "address",
-  "address",
   "uint256",
   "uint8",
   "uint256",
   "bytes"
 ];
 
-let MockNMR;
+let CountdownGriefing;
 
 before(async () => {
   MockNMR = await deployer.deploy(MockNMRArtifact);
+  CountdownGriefing = await deployer.deploy(
+    CountdownGriefingArtifact,
+    false,
+    MockNMR.contractAddress
+  );
 });
 
 function runFactoryTest() {
@@ -45,7 +50,6 @@ function runFactoryTest() {
   describe(factoryName, () => {
     it("setups test", () => {
       const createArgs = [
-        MockNMR.contractAddress,
         owner,
         staker,
         counterparty,
@@ -61,9 +65,10 @@ function runFactoryTest() {
         instanceType,
         createTypes,
         createArgs,
-        OneWayGriefing_FactoryArtifact,
+        CountdownGriefing_FactoryArtifact,
         ErasureAgreementsRegistryArtifact,
-        ErasurePostsRegistryArtifact
+        ErasurePostsRegistryArtifact,
+        [CountdownGriefing.contractAddress]
       );
     });
   });

--- a/test/agreements/SimpleGriefing.js
+++ b/test/agreements/SimpleGriefing.js
@@ -56,8 +56,12 @@ describe("SimpleGriefing", function() {
   before(async () => {
     deployer = createDeployer();
 
-    this.SimpleGriefing = await deployer.deploy(SimpleGriefingArtifact);
     this.MockNMR = await deployer.deploy(MockNMRArtifact);
+    this.SimpleGriefing = await deployer.deploy(
+      SimpleGriefingArtifact,
+      false,
+      this.MockNMR.contractAddress
+    );
 
     // fill the token balances of the counterparty and staker
     // counterparty & staker has 1,000 * 10^18 each
@@ -75,10 +79,7 @@ describe("SimpleGriefing", function() {
   describe("SimpleGriefing.initialize", () => {
     it("should revert when caller is not contract", async () => {
       await assert.revertWith(
-        this.SimpleGriefing.initialize(
-          this.MockNMR.contractAddress,
-          ...initArgs
-        ),
+        this.SimpleGriefing.initialize(...initArgs),
         "must be called within contract constructor"
       );
     });
@@ -150,7 +151,6 @@ describe("SimpleGriefing", function() {
     it("should revert when not initialized from constructor", async () => {
       const initArgs = [
         this.SimpleGriefing.contractAddress,
-        this.MockNMR.contractAddress,
         operator,
         staker,
         counterparty,

--- a/test/agreements/SimpleGriefing_Factory.js
+++ b/test/agreements/SimpleGriefing_Factory.js
@@ -1,5 +1,6 @@
 // require artifacts
 const SimpleGriefing_FactoryArtifact = require("../../build/SimpleGriefing_Factory.json");
+const SimpleGriefingArtifact = require("../../build/SimpleGriefing.json");
 const MockNMRArtifact = require("../../build/MockNMR.json");
 const ErasureAgreementsRegistryArtifact = require("../../build/Erasure_Agreements.json");
 const ErasurePostsRegistryArtifact = require("../../build/Erasure_Posts.json");
@@ -21,16 +22,20 @@ const createTypes = [
   "address",
   "address",
   "address",
-  "address",
   "uint256",
   "uint8",
   "bytes"
 ];
 
-let MockNMR;
+let SimpleGriefing;
 
 before(async () => {
   MockNMR = await deployer.deploy(MockNMRArtifact);
+  SimpleGriefing = await deployer.deploy(
+    SimpleGriefingArtifact,
+    false,
+    MockNMR.contractAddress
+  );
 });
 
 function runFactoryTest() {
@@ -44,7 +49,6 @@ function runFactoryTest() {
   describe(factoryName, () => {
     it("setups test", () => {
       const createArgs = [
-        MockNMR.contractAddress,
         owner,
         staker,
         counterparty,
@@ -61,7 +65,8 @@ function runFactoryTest() {
         createArgs,
         SimpleGriefing_FactoryArtifact,
         ErasureAgreementsRegistryArtifact,
-        ErasurePostsRegistryArtifact
+        ErasurePostsRegistryArtifact,
+        [SimpleGriefing.contractAddress]
       );
     });
   });

--- a/test/posts/Feed.js
+++ b/test/posts/Feed.js
@@ -2,23 +2,15 @@ const etherlime = require("etherlime-lib");
 
 const { createDeployer } = require("../helpers/setup");
 const {
-<<<<<<< HEAD
-  hexlify,
-  createInstanceAddress,
-  createInstanceAddressWithCallData,
-  createSelector,
-  createMultihashSha256,
-  abiEncodeWithSelector
-=======
   createInstanceAddressWithInitData,
   createSelector,
   abiEncodeWithSelector,
   createMultihashSha256
->>>>>>> Feed_Factory use passed in template
 } = require("../helpers/utils");
 
 // artifacts
 const TestFeedArtifact = require("../../build/TestFeed.json");
+const TestPostArtifact = require("../../build/TestPost.json");
 const FeedFactoryArtifact = require("../../build/Feed_Factory.json");
 const PostFactoryArtifact = require("../../build/Post_Factory.json");
 const ErasurePostsArtifact = require("../../build/Erasure_Posts.json");
@@ -60,7 +52,7 @@ describe("Feed", function() {
     postVariableMetadata
   ];
   const createPostCallData = abiEncodeWithSelector(
-    'initialize',
+    "initialize",
     createPostABITypes,
     createPostABIValues
   );
@@ -83,10 +75,18 @@ describe("Feed", function() {
     let callData;
 
     if (validInit) {
-      callData = abiEncodeWithSelector('initialize', ["address", "address", "bytes"], args);
+      callData = abiEncodeWithSelector(
+        "initialize",
+        ["address", "address", "bytes"],
+        args
+      );
     } else {
       // invalid callData is missing first address
-      callData = abiEncodeWithSelector('initialize', ["bytes"], [feedStaticMetadata]);
+      callData = abiEncodeWithSelector(
+        "initialize",
+        ["bytes"],
+        [feedStaticMetadata]
+      );
     }
 
     const txn = await this.FeedFactory.from(creator).create(callData);
@@ -117,6 +117,7 @@ describe("Feed", function() {
     this.PostRegistry = await deployer.deploy(ErasurePostsArtifact);
 
     this.FeedTemplate = await deployer.deploy(TestFeedArtifact);
+    this.PostTemplate = await deployer.deploy(TestPostArtifact);
 
     this.FeedFactory = await deployer.deploy(
       FeedFactoryArtifact,
@@ -133,7 +134,8 @@ describe("Feed", function() {
     this.PostFactory = await deployer.deploy(
       PostFactoryArtifact,
       false,
-      this.PostRegistry.contractAddress
+      this.PostRegistry.contractAddress,
+      this.PostTemplate.contractAddress
     );
   });
 
@@ -323,7 +325,7 @@ describe("Feed", function() {
     // malformed post init data
     it("should revert with malformed post init data", async () => {
       const callData = abiEncodeWithSelector(
-        'initialize',
+        "initialize",
         ["bytes", "bytes"], // missing 1 bytes parameter
         [proofHash, postStaticMetadata]
       );

--- a/test/posts/Feed.js
+++ b/test/posts/Feed.js
@@ -2,17 +2,24 @@ const etherlime = require("etherlime-lib");
 
 const { createDeployer } = require("../helpers/setup");
 const {
+<<<<<<< HEAD
   hexlify,
   createInstanceAddress,
   createInstanceAddressWithCallData,
   createSelector,
   createMultihashSha256,
   abiEncodeWithSelector
+=======
+  createInstanceAddressWithInitData,
+  createSelector,
+  abiEncodeWithSelector,
+  createMultihashSha256
+>>>>>>> Feed_Factory use passed in template
 } = require("../helpers/utils");
 
 // artifacts
 const TestFeedArtifact = require("../../build/TestFeed.json");
-const FeedFactoryArtifact = require("../../build/TestFeedFactory.json");
+const FeedFactoryArtifact = require("../../build/Feed_Factory.json");
 const PostFactoryArtifact = require("../../build/Post_Factory.json");
 const ErasurePostsArtifact = require("../../build/Erasure_Posts.json");
 
@@ -109,19 +116,19 @@ describe("Feed", function() {
 
     this.PostRegistry = await deployer.deploy(ErasurePostsArtifact);
 
+    this.FeedTemplate = await deployer.deploy(TestFeedArtifact);
+
     this.FeedFactory = await deployer.deploy(
       FeedFactoryArtifact,
       false,
-      this.PostRegistry.contractAddress
+      this.PostRegistry.contractAddress,
+      this.FeedTemplate.contractAddress
     );
 
     await this.PostRegistry.from(creator).addFactory(
       this.FeedFactory.contractAddress,
       "0x"
     );
-
-    // // template contract from FeedFactory
-    this.FeedAddress = await this.FeedFactory.getTemplate();
 
     this.PostFactory = await deployer.deploy(
       PostFactoryArtifact,
@@ -135,7 +142,7 @@ describe("Feed", function() {
       await assert.revert(deployTestFeed(false));
     });
 
-    it("should initialize post", async () => {
+    it("should initialize feed", async () => {
       this.TestFeed = await deployTestFeed(true);
 
       // getPostRegistry

--- a/test/posts/Feed_Factory.js
+++ b/test/posts/Feed_Factory.js
@@ -1,4 +1,5 @@
 // require artifacts
+const FeedArtifact = require("../../build/Feed.json");
 const FeedFactoryArtifact = require("../../build/Feed_Factory.json");
 const ErasureAgreementsArtifact = require("../../build/Erasure_Agreements.json");
 const ErasurePostsArtifact = require("../../build/Erasure_Posts.json");
@@ -19,10 +20,10 @@ const staticMetadata = ethers.utils.keccak256(
 const createTypes = ["address", "bytes"];
 const localCreateTypes = ["address", "address", "bytes"];
 
-let PostRegistry;
+let FeedTemplate;
 
 before(async () => {
-  PostRegistry = await deployer.deploy(ErasurePostsArtifact);
+  FeedTemplate = await deployer.deploy(FeedArtifact);
 });
 
 function runFactoryTest() {
@@ -41,6 +42,7 @@ function runFactoryTest() {
         FeedFactoryArtifact,
         ErasurePostsArtifact, // correct registry
         ErasureAgreementsArtifact, // wrong registry
+        [FeedTemplate.contractAddress],
         localCreateTypes,
         function() {
           return [creator, this.Registry.contractAddress, staticMetadata];

--- a/test/posts/Post.js
+++ b/test/posts/Post.js
@@ -1,7 +1,11 @@
 const etherlime = require("etherlime-lib");
 const { createDeployer } = require("../helpers/setup");
-const { hexlify, createMultihashSha256, abiEncodeWithSelector } = require("../helpers/utils");
-const PostFactoryArtifact = require("../../build/TestPostFactory.json");
+const {
+  hexlify,
+  createMultihashSha256,
+  abiEncodeWithSelector
+} = require("../helpers/utils");
+const PostFactoryArtifact = require("../../build/Post_Factory.json");
 const TestPostArtifact = require("../../build/TestPost.json");
 const ErasurePostsArtifact = require("../../build/Erasure_Posts.json");
 
@@ -37,7 +41,11 @@ describe("Post", () => {
   ];
 
   const deployTestPost = async (args = createPostAbiValues) => {
-    const callData = abiEncodeWithSelector('initialize', createPostAbiTypes, args);
+    const callData = abiEncodeWithSelector(
+      "initialize",
+      createPostAbiTypes,
+      args
+    );
     const txn = await this.PostFactory.from(creator).create(callData);
 
     const receipt = await this.PostFactory.verboseWaitForTransaction(txn);
@@ -64,10 +72,13 @@ describe("Post", () => {
 
     this.PostRegistry = await deployer.deploy(ErasurePostsArtifact);
 
+    this.PostTemplate = await deployer.deploy(TestPostArtifact);
+
     this.PostFactory = await deployer.deploy(
       PostFactoryArtifact,
       false,
-      this.PostRegistry.contractAddress
+      this.PostRegistry.contractAddress,
+      this.PostTemplate.contractAddress
     );
 
     await this.PostRegistry.from(creator).addFactory(

--- a/test/posts/Post_Factory.js
+++ b/test/posts/Post_Factory.js
@@ -1,5 +1,6 @@
 // require artifacts
 const PostFactoryArtifact = require("../../build/Post_Factory.json");
+const PostArtifact = require("../../build/TestPost.json");
 const ErasureAgreementsRegistryArtifact = require("../../build/Erasure_Agreements.json");
 const ErasurePostsRegistryArtifact = require("../../build/Erasure_Posts.json");
 
@@ -25,6 +26,12 @@ const variableMetadata = ethers.utils.keccak256(
 const createTypes = ["address", "bytes", "bytes", "bytes"];
 const createArgs = [creator, proofHash, staticMetadata, variableMetadata];
 
+let PostTemplate;
+
+before(async () => {
+  PostTemplate = await deployer.deploy(PostArtifact);
+});
+
 function runFactoryTest() {
   const deployer = createDeployer();
 
@@ -38,7 +45,8 @@ function runFactoryTest() {
         createArgs,
         PostFactoryArtifact,
         ErasurePostsRegistryArtifact,
-        ErasureAgreementsRegistryArtifact
+        ErasureAgreementsRegistryArtifact,
+        [PostTemplate.contractAddress]
       );
     });
   });


### PR DESCRIPTION
Issues addressed are:
- fixes #177
- fixes #174

The nice outcome of these changes are that we have removed the `TestPostFactory.sol` and `TestFeedFactory.sol` files. These test factories were necessary because of the inability to pass in template addresses.