### PR TITLE
Countdown with length 0

### DIFF
--- a/contracts/modules/Countdown.sol
+++ b/contracts/modules/Countdown.sol
@@ -17,13 +17,11 @@ contract Countdown is Deadline {
     // state functions
 
     function _setLength(uint256 length) internal {
-        require(length != 0, "length cannot be zero");
         _length = length;
         emit LengthSet(length);
     }
 
     function _start() internal returns (uint256 deadline) {
-        require(_length != 0, "length not set");
         deadline = _length.add(now);
         Deadline._setDeadline(deadline);
     }
@@ -37,9 +35,9 @@ contract Countdown is Deadline {
     // if Deadline._setDeadline or Countdown._setLength is not called,
     // isOver will yield false
     function isOver() public view returns (bool status) {
-        // when length or deadline not set,
+        // when deadline not set,
         // countdown has not started, hence not isOver
-        if (_length == 0 || Deadline.getDeadline() == 0) {
+        if (Deadline.getDeadline() == 0) {
             status = false;
         } else {
             status = Deadline.isAfterDeadline();

--- a/test/agreements/CountdownGriefing.js
+++ b/test/agreements/CountdownGriefing.js
@@ -121,6 +121,24 @@ describe("CountdownGriefing", function() {
       );
     });
 
+    it("should initialize contract with countdownLength=0", async () => {
+      const countdownLength = 0;
+
+      this.TestCountdownGriefing = await deployAgreement([
+        operator,
+        staker,
+        counterparty,
+        ratioE18,
+        ratioType,
+        countdownLength,
+        Buffer.from(staticMetadata)
+      ]);
+
+      // Countdown._setLength
+      const actualLength = await this.TestCountdownGriefing.getLength();
+      assert.equal(actualLength, countdownLength);
+    });
+
     it("should initialize contract", async () => {
       this.TestCountdownGriefing = await deployAgreement();
 
@@ -164,13 +182,6 @@ describe("CountdownGriefing", function() {
       // Countdown._setLength
       const actualLength = await this.TestCountdownGriefing.getLength();
       assert.equal(actualLength, countdownLength);
-
-      // Test for event logs
-      // console.log(this.TestCountdownGriefing);
-      // const receipt = await this.TestCountdownGriefing.verboseWaitForTransaction(
-      //   this.TestCountdownGriefing.deployTransaction
-      // );
-      // console.log(receipt.events);
     });
 
     it("should revert when not initialized from constructor", async () => {

--- a/test/modules/Countdown.js
+++ b/test/modules/Countdown.js
@@ -1,7 +1,6 @@
 const { createDeployer } = require("../helpers/setup");
 
 describe("Countdown", function() {
-
   let wallets = {
     numerai: accounts[0],
     seller: accounts[1],
@@ -83,11 +82,9 @@ describe("Countdown", function() {
   });
 
   describe("Countdown._start", () => {
-    it("reverts when length not set", async () => {
-      await assert.revertWith(
-        contracts.TestCountdown.instance.start(),
-        "length not set"
-      );
+    it("starts countdown when length not set", async () => {
+      const txn = await contracts.TestCountdown.instance.start();
+      await assert.emit(txn, "DeadlineSet");
     });
 
     it("starts countdown correctly", async () => {

--- a/test/modules/Countdown.js
+++ b/test/modules/Countdown.js
@@ -87,6 +87,14 @@ describe("Countdown", function() {
       await assert.emit(txn, "DeadlineSet");
     });
 
+    it("starts countdown when length=0", async () => {
+      const length = 0;
+      await contracts.TestCountdown.instance.setLength(length);
+
+      const txn = await contracts.TestCountdown.instance.start();
+      await assert.emit(txn, "DeadlineSet");
+    });
+
     it("starts countdown correctly", async () => {
       const length = 1000;
       await contracts.TestCountdown.instance.setLength(length);


### PR DESCRIPTION
fixes https://github.com/erasureprotocol/erasure-protocol/issues/242

- Start can be called only once, but is okay with accepting a length of 0 from `initialize`
- `isOver` and `timeRemaining` have similar behaviors. 